### PR TITLE
Fix syntax error and redirection

### DIFF
--- a/recipes/geoip.rb
+++ b/recipes/geoip.rb
@@ -6,10 +6,10 @@
 cron 'run geoip update' do
   minute '0'
   hour '1'
-  day '*'
+  day '1-7'
   month '*'
   weekday '2'
   command <<-EOH
-    [ `date +\%d` -le 7 ] && wget "#{node['nginx']['geoip']['country_dat_url']}" -O "#{node['nginx']['geoip']['path']}/GeoIP.dat.gz" && mv #{node['nginx']['geoip']['path']}/GeoIP.dat #{node['nginx']['geoip']['path']}/GeoIP.dat.bak && gzip -d #{node['nginx']['geoip']['path']}/GeoIP.dat.gz > /dev/null 2>&1
+    wget -q "#{node['nginx']['geoip']['country_dat_url']}" -O "#{node['nginx']['geoip']['path']}/GeoIP.dat.gz" && mv #{node['nginx']['geoip']['path']}/GeoIP.dat #{node['nginx']['geoip']['path']}/GeoIP.dat.bak && gzip -d #{node['nginx']['geoip']['path']}/GeoIP.dat.gz
   EOH
 end


### PR DESCRIPTION
The original cron job contained an unescaped percent sign which was
apparently interpreted as a multiline-escape.
This removes the need for a percent sign alltogether by using cron's
syntax to check if we're in the first 7 days of the month.

I also changed the output redirection (which was only affecting the last
command anyways) and made wget be quiet by default.

Fixes #1